### PR TITLE
Remove cv bridge

### DIFF
--- a/bs_models/CMakeLists.txt
+++ b/bs_models/CMakeLists.txt
@@ -40,13 +40,13 @@ find_package(
     bs_constraints
     bs_common
     bs_variables
-    cv_bridge
     basalt)
 
 find_package(Ceres REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED)
 find_package(Catch2 REQUIRED)
+FIND_PACKAGE(OpenCV 4.5.2 REQUIRED COMPONENTS)
 
 add_message_files(
   DIRECTORY
@@ -94,7 +94,6 @@ catkin_package(
     bs_constraints
     bs_common
     bs_variables
-    cv_bridge
     basalt
   DEPENDS
     Boost

--- a/bs_models/include/bs_models/camera_to_camera/visual_inertial_odom.h
+++ b/bs_models/include/bs_models/camera_to_camera/visual_inertial_odom.h
@@ -30,7 +30,8 @@
 #include <beam_cv/geometry/PoseRefinement.h>
 #include <beam_cv/trackers/Trackers.h>
 
-namespace bs_models { namespace camera_to_camera {
+namespace bs_models {
+namespace camera_to_camera {
 
 class VisualInertialOdom : public fuse_core::AsyncSensorModel {
 public:
@@ -172,12 +173,6 @@ private:
   void PublishLandmarkIDs(const std::vector<uint64_t>& ids);
 
   /**
-   * @brief Converts ros image message to opencv image
-   * @param msg image message to convert to cv mat
-   */
-  cv::Mat ExtractImage(const sensor_msgs::Image& msg);
-
-  /**
    * @brief Computes the mean parallax between images at two times
    * @param t1 time of first image
    * @param t2 time of second image
@@ -235,4 +230,5 @@ protected:
       bs_common::ExtrinsicsLookup::GetInstance();
 };
 
-}} // namespace bs_models::camera_to_camera
+} // namespace camera_to_camera
+} // namespace bs_models

--- a/bs_models/package.xml
+++ b/bs_models/package.xml
@@ -26,7 +26,6 @@
   <depend>tf2_2d</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>cv_bridge</depend>
   <depend>basalt</depend>
 
   <depend>fuse_constraints</depend>

--- a/bs_models/src/camera_to_camera/visual_inertial_odom.cpp
+++ b/bs_models/src/camera_to_camera/visual_inertial_odom.cpp
@@ -3,25 +3,24 @@
 #include <fuse_core/transaction.h>
 #include <pluginlib/class_list_macros.h>
 
-#include <cv_bridge/cv_bridge.h>
 #include <nlohmann/json.hpp>
 #include <std_msgs/UInt64MultiArray.h>
 
+#include <beam_cv/OpenCVConversions.h>
 #include <beam_cv/descriptors/Descriptors.h>
 #include <beam_cv/detectors/Detectors.h>
 #include <beam_cv/geometry/AbsolutePoseEstimator.h>
 #include <beam_cv/geometry/Triangulation.h>
-#include <bs_common/utils.h>
 
 // Register this sensor model with ROS as a plugin.
 PLUGINLIB_EXPORT_CLASS(bs_models::camera_to_camera::VisualInertialOdom,
                        fuse_core::SensorModel)
 
-namespace bs_models { namespace camera_to_camera {
+namespace bs_models {
+namespace camera_to_camera {
 
 VisualInertialOdom::VisualInertialOdom()
-    : fuse_core::AsyncSensorModel(1),
-      device_id_(fuse_core::uuid::NIL),
+    : fuse_core::AsyncSensorModel(1), device_id_(fuse_core::uuid::NIL),
       throttled_image_callback_(std::bind(&VisualInertialOdom::processImage,
                                           this, std::placeholders::_1)),
       throttled_imu_callback_(std::bind(&VisualInertialOdom::processIMU, this,
@@ -123,10 +122,13 @@ void VisualInertialOdom::processImage(const sensor_msgs::Image::ConstPtr& msg) {
       return;
     }
     // add image to tracker
-    tracker_->AddImage(ExtractImage(image_buffer_.front()), img_time);
+    tracker_->AddImage(
+        beam_cv::OpenCVConversions::ImgToMat(image_buffer_.front()), img_time);
     // process if in initialization mode
     if (!initializer_->Initialized()) {
-      tracker_->AddImage(ExtractImage(image_buffer_.front()), img_time);
+      tracker_->AddImage(
+          beam_cv::OpenCVConversions::ImgToMat(image_buffer_.front()),
+          img_time);
       if ((img_time - keyframes_.back().Stamp()).toSec() >= 1.0) {
         bs_models::camera_to_camera::Keyframe kf(img_time,
                                                  image_buffer_.front());
@@ -389,7 +391,8 @@ void VisualInertialOdom::ExtendMap(
         visual_map_->AddConstraint(prev_kf_time, id, pixel_prv_kf, transaction);
         visual_map_->AddConstraint(cur_kf_time, id, pixel_cur_kf, transaction);
       }
-    } catch (const std::out_of_range& oor) {}
+    } catch (const std::out_of_range& oor) {
+    }
   }
   ROS_INFO("Added %zu new landmarks.", added_lms);
   // add inertial constraint
@@ -433,7 +436,9 @@ void VisualInertialOdom::NotifyNewKeyframe(
 
 void VisualInertialOdom::PublishSlamChunk() {
   // this just makes sure the visual map has the most recent variables
-  for (auto& kf : keyframes_) { visual_map_->GetPose(kf.Stamp()); }
+  for (auto& kf : keyframes_) {
+    visual_map_->GetPose(kf.Stamp());
+  }
   // only once keyframes reaches the max window size, publish the keyframe
   if (keyframes_.size() == camera_params_.keyframe_window_size) {
     SlamChunkMsg slam_chunk;
@@ -454,7 +459,9 @@ void VisualInertialOdom::PublishSlamChunk() {
       ros::Time stamp;
       stamp.fromNSec(it.first);
       trajectory.stamps.push_back(stamp.toSec());
-      for (auto& x : pose) { trajectory.poses.push_back(x); }
+      for (auto& x : pose) {
+        trajectory.poses.push_back(x);
+      }
     }
     slam_chunk.trajectory_measurement = trajectory;
     // camera measurements
@@ -487,18 +494,10 @@ void VisualInertialOdom::PublishSlamChunk() {
 
 void VisualInertialOdom::PublishLandmarkIDs(const std::vector<uint64_t>& ids) {
   std_msgs::UInt64MultiArray landmark_msg;
-  for (auto& id : ids) { landmark_msg.data.push_back(id); }
-  landmark_publisher_.publish(landmark_msg);
-}
-
-cv::Mat VisualInertialOdom::ExtractImage(const sensor_msgs::Image& msg) {
-  cv_bridge::CvImagePtr cv_ptr;
-  try {
-    cv_ptr = cv_bridge::toCvCopy(msg, msg.encoding);
-  } catch (cv_bridge::Exception& e) {
-    ROS_ERROR("cv_bridge exception: %s", e.what());
+  for (auto& id : ids) {
+    landmark_msg.data.push_back(id);
   }
-  return cv_ptr->image;
+  landmark_publisher_.publish(landmark_msg);
 }
 
 double VisualInertialOdom::ComputeAvgParallax(
@@ -512,11 +511,13 @@ double VisualInertialOdom::ComputeAvgParallax(
       Eigen::Vector2d p2 = tracker_->Get(t2, id);
       double dist = beam::distance(p1, p2);
       parallaxes.push_back(dist);
-    } catch (const std::out_of_range& oor) {}
+    } catch (const std::out_of_range& oor) {
+    }
   }
   // sort and find median parallax
   std::sort(parallaxes.begin(), parallaxes.end());
   return parallaxes[parallaxes.size() / 2];
 }
 
-}} // namespace bs_models::camera_to_camera
+} // namespace camera_to_camera
+} // namespace bs_models


### PR DESCRIPTION
you need the remove_cv_bridge18 branch of libbeam for this to work, since the ImgToMat function that replaces cv_bridge is defined in beam_cv/Utils on that branch.  this compiles on ubuntu 18 but I'm not quite familiar with the launch files so feel free to test