### PR TITLE
Removed basalt dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This repo contains beam's lidar-camera-inertial SLAM code. All other SLAM code i
 * fuse: https://github.com/locusrobotics/fuse (kinetic-devel branch for ROS Kinetic, devel branch for ROS Melodic)
 * tf2_2d: https://github.com/locusrobotics/tf2_2d.git
 * qwt: sudo apt-get install libqwt-dev
-* basalt: https://github.com/BEAMRobotics/basalt-headers-mirror
 * sophus: https://github.com/strasdat/Sophus (tested at commit 936265f)
 
 ## Known issues:

--- a/bs_models/CMakeLists.txt
+++ b/bs_models/CMakeLists.txt
@@ -196,27 +196,27 @@ if(CATKIN_ENABLE_TESTING)
       CXX_STANDARD_REQUIRED YES
   )
 
-  # IMU preintegration tests
-  find_package(basalt REQUIRED)
-  catkin_add_gtest(${PROJECT_NAME}_imu_preintegration_tests
-    tests/imu_preintegration_tests.cpp
-  )
-  target_include_directories(${PROJECT_NAME}_imu_preintegration_tests
-    PUBLIC
-    tests/include
-    ${basalt_INCLUDE_DIRS}
-  )
-  target_link_libraries(${PROJECT_NAME}_imu_preintegration_tests
-    ${PROJECT_NAME}
-    ${catkin_LIBRARIES}
-    ${CERES_LIBRARIES}
-    ${basalt_LIBRARIES}
-  )
-  set_target_properties(${PROJECT_NAME}_imu_preintegration_tests
-    PROPERTIES
-      CXX_STANDARD 14
-      CXX_STANDARD_REQUIRED YES
-  )
+  # IMU preintegration tests (need to install basalt for these)
+  # find_package(basalt REQUIRED)
+  #   catkin_add_gtest(${PROJECT_NAME}_imu_preintegration_tests
+  #     tests/imu_preintegration_tests.cpp
+  #   )
+  #   target_include_directories(${PROJECT_NAME}_imu_preintegration_tests
+  #     PUBLIC
+  #     tests/include
+  #     ${basalt_INCLUDE_DIRS}
+  #   )
+  #   target_link_libraries(${PROJECT_NAME}_imu_preintegration_tests
+  # ${PROJECT_NAME}
+  # ${catkin_LIBRARIES}
+  # ${CERES_LIBRARIES}
+  # ${basalt_LIBRARIES}
+  #   )
+  #   set_target_properties(${PROJECT_NAME}_imu_preintegration_tests
+  #     PROPERTIES
+  #       CXX_STANDARD 14
+  #       CXX_STANDARD_REQUIRED YES
+  #   )
 
   # Reprojection tests
   catkin_add_gtest(${PROJECT_NAME}_reprojection_test


### PR DESCRIPTION
I had some issues with installing beam_models because of basalt, so I commented out the basalt dependency and IMU pre-integration tests in bs_models/CMakeLists.txt and removed it from the Readme. I don't think these are necessary for someone just trying to use the package.

Zaid